### PR TITLE
simplify actions work with setup opa action from opa org

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,11 +6,7 @@ jobs:
     name: Confectionery Integration Checks
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/setup-go@v2
-    - run: |
-        go get github.com/open-policy-agent/opa
-        go install github.com/open-policy-agent/opa
-    - run: echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
+    - uses: open-policy-agent/setup-opa@v1
     - run: ./scripts/check-naming.sh
     - run: ./scripts/opa-format.sh
     - run: opa test rules test-files


### PR DESCRIPTION
Noticed this (https://github.com/open-policy-agent/setup-opa) got adopted by the OPA org and figured it's a cleaner approach then what we were doing previously. It auto adds OPA to the path as well.