### PR TITLE
Rephrasing

### DIFF
--- a/rules/terraform/azure/storage-account/public_storage_account.rego
+++ b/rules/terraform/azure/storage-account/public_storage_account.rego
@@ -8,8 +8,8 @@ azurerm_storage_account = fugue.resources("azurerm_storage_account")
 
 # Auxiliary function checking if allow_blob_public_access is true
 
-not_valid(resource) {
-	resource.allow_blob_public_access == true
+valid(resource) {
+	resource.allow_blob_public_access == false
 }
 
 # Regula expects advanced rules to contain a `policy` rule that holds a set
@@ -17,12 +17,12 @@ not_valid(resource) {
 
 policy[p] {
 	resource = azurerm_storage_account[_]
-	not not_valid(resource)
+	valid(resource)
 	p = fugue.allow_resource(resource)
 }
 
 policy[p] {
 	resource = azurerm_storage_account[_]
-	not_valid(resource)
+	not valid(resource)
 	p = fugue.deny_resource_with_message(resource, "Storage Accounts should not be publicly accessible.")
 }


### PR DESCRIPTION
Having a double neg like `not not_valid` makes readability confusing.